### PR TITLE
Resolve expressions to their string

### DIFF
--- a/src/Models/Scopes/Product/WithProductStockScopeMsi.php
+++ b/src/Models/Scopes/Product/WithProductStockScopeMsi.php
@@ -2,6 +2,7 @@
 
 namespace Rapidez\Msi\Models\Scopes\Product;
 
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -15,6 +16,8 @@ class WithProductStockScopeMsi implements Scope
     {
         // Remove the existing "in_stock" select.
         $builder->getQuery()->columns = collect($builder->getQuery()->columns)->filter(function ($column) {
+            $column = $column instanceof Expression ? $column->getValue($builder->getQuery()->getGrammar()) : $column;
+
             return !Str::endsWith((string)$column, 'in_stock');
         })->toArray();
 

--- a/src/Models/Scopes/Product/WithProductStockScopeMsi.php
+++ b/src/Models/Scopes/Product/WithProductStockScopeMsi.php
@@ -15,7 +15,7 @@ class WithProductStockScopeMsi implements Scope
     public function apply(Builder $builder, Model $model)
     {
         // Remove the existing "in_stock" select.
-        $builder->getQuery()->columns = collect($builder->getQuery()->columns)->filter(function ($column) {
+        $builder->getQuery()->columns = collect($builder->getQuery()->columns)->filter(function ($column) use ($builder) {
             $column = $column instanceof Expression ? $column->getValue($builder->getQuery()->getGrammar()) : $column;
 
             return !Str::endsWith((string)$column, 'in_stock');


### PR DESCRIPTION
This fixes errors when selects aren't simple strings like:
`COALESCE(ANY_VALUE(attribute_1.value), ANY_VALUE(attribute_0.value)) AS attribute`